### PR TITLE
fix: remove explicit reset call in identify event

### DIFF
--- a/moengage/src/main/java/com/rudderstack/android/integrations/moengage/MoengageIntegrationFactory.java
+++ b/moengage/src/main/java/com/rudderstack/android/integrations/moengage/MoengageIntegrationFactory.java
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.moengage.core.MoECoreHelper;
-import com.moengage.core.MoEngage;
 import com.moengage.core.analytics.MoEAnalyticsHelper;
 import com.moengage.core.Properties;
 import com.moengage.core.model.AppStatus;
@@ -41,7 +40,7 @@ public class MoengageIntegrationFactory extends RudderIntegration<MoEAnalyticsHe
     public static Factory FACTORY = new Factory() {
         @Override
         public RudderIntegration<?> create(Object settings, RudderClient client, RudderConfig rudderConfig) {
-            return new MoengageIntegrationFactory(client);
+            return new MoengageIntegrationFactory();
         }
 
         @Override
@@ -62,9 +61,9 @@ public class MoengageIntegrationFactory extends RudderIntegration<MoEAnalyticsHe
     private static final List<String> IDENTIFY_TRAITS = Arrays.asList("birthday", "email", "firstname",
             "lastname", "name", "gender", "phone", "address", "age");
 
-    private MoengageIntegrationFactory(@NonNull RudderClient client) {
+    private MoengageIntegrationFactory() {
         this.helper = MoEAnalyticsHelper.INSTANCE;
-        this.context = client.getApplication();
+        this.context = RudderClient.getApplication();
     }
 
     private void processRudderEvent(RudderMessage element) {
@@ -94,8 +93,6 @@ public class MoengageIntegrationFactory extends RudderIntegration<MoEAnalyticsHe
                     break;
                 // identifying a user in the MoEngage and setting attributes in his profile
                 case MessageType.IDENTIFY:
-                    // logging out the previous user if any existing
-                    reset();
                     String userId = element.getUserId();
                     if (!TextUtils.isEmpty(userId)) {
                         // logging in the user into MoEngage

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -49,6 +49,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging:23.1.1'
 
     // MoEngage
-    implementation("com.moengage:moe-android-sdk:12.5.04")
+    implementation("com.moengage:moe-android-sdk:[12.7,13.0)")
 }
 


### PR DESCRIPTION
**Fixes** # (*issue*)

- An explicit Reset call is being made during Identify events, which is causing issues with user merging. This becomes problematic when a user installs the app for the first time, performs some events, and then makes an Identify call. In this case, since the Reset call is explicitly made, a new MoEngage ID is generated, which hampers the user merging process.
- Ideally, in the aforementioned scenario, the MoEngage ID should remain linked to the same user after making an Identify call.
- Additionally, there is no need to make a Reset call during Identify events, as the Identify call itself automatically logs out the user if they are already logged in.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
