### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN/App Token [SEC-58]

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write # to create commits, tags, and branches
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to resolve team reviewers
 
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read # to read repository contents
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/')
@@ -19,9 +19,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and branches
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set Node 16
@@ -29,23 +39,18 @@ jobs:
         with:
           node-version: 16
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
-
       # Calculate the next release version based on conventional semantic release
       - name: Create release branch
         id: create-release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
           git fetch origin master --depth=1
           git merge origin/master
           current_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
-          
+
           npm ci
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
@@ -65,22 +70,29 @@ jobs:
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
-      - name: Update changelog & bump version
+      - name: Update changelog & bump version (skip commit)
         id: finish-release
         run: |
           npm ci
-          npx standard-version -a --skip.tag
+          npx standard-version -a --skip.commit --skip.tag
 
-      - name: Push new version in release branch
-        run: |
-          git push
+      - name: Create verified commit via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            gradle.properties
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body:  ":crown: *An automated PR*"
           pr_reviewer: 'itsdebs'

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -63,8 +63,13 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
+
+          # Create branch via GitHub API (no local git push needed)
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/$branch_name" \
+            -f sha="$BASE_SHA"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT

--- a/.github/workflows/notion_pr_sync.yml
+++ b/.github/workflows/notion_pr_sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -13,29 +13,43 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: read # to read repository contents
     name: Publish new release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }} || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
+
       - name: Extract version from branch name (for release branches)
         id: extract-version
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          if [ "$BRANCH_NAME" = "" ]; then BRANCH_NAME=${{ github.event.inputs.version }}
+          BRANCH_NAME="$PR_HEAD_REF"
+          if [ "$BRANCH_NAME" = "" ]; then BRANCH_NAME="$INPUT_VERSION"
           fi
           echo "BRANCH_NAME considered: ${BRANCH_NAME}"
           VERSION=${BRANCH_NAME#release/}
-          
+
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -43,21 +57,20 @@ jobs:
         with:
           node-version: 16
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
+      - name: Create verified tag via API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
+          gh api repos/${{ github.repository }}/git/refs \
+            -f ref="refs/tags/v${{ steps.extract-version.outputs.release_version }}" \
+            -f sha="${{ github.sha }}"
 
-      - name: Create GitHub Release & Tag
+      - name: Create GitHub Release
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
-          git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular
 
       - name: Delete release branch
@@ -66,4 +79,4 @@ jobs:
         with:
           branches: 'release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Migrates all PAT usages to GITHUB_TOKEN or GitHub App Token
- Adds explicit permissions at job level with comments explaining why
- Fixes signed commit patterns to use GitHub API for verified commits
- **Simplifies draft_new_release.yml with GitHub API branch creation**

### Migration Details
| File | Change | Why |
|------|--------|-----|
| notion_pr_sync.yml | PAT → GITHUB_TOKEN, added permissions: pull-requests: read | Only reads PR metadata, no write needed |
| draft_new_release.yml | PAT → App Token, added signed-commit action + API branch creation | Verified commits require GitHub API instead of git push |
| publish-new-github-release.yml | PAT → App Token, uses API for tags | Verified tags and commits require GitHub API |

### Migration Pattern Evolution

1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

### Key Simplifications in draft_new_release.yml
- **REMOVED**: `git checkout -b` + `git push --set-upstream origin` pattern
- **REPLACED WITH**: `gh api repos/.../git/refs` to create branch directly on GitHub
- **BENEFIT**: Cleaner code, no need for token-in-URL hacks, consistent with signed-commit pattern

### Security Fixes
- **template-injection fix**: Prevents attackers from injecting malicious code via PR titles/branch names in publish-new-github-release.yml
- **excessive-permissions fix**: Reduces blast radius by using minimal job-level permissions
- **signed commits**: All commits now verified through GitHub API instead of git push

### Key Changes in Release Workflows
- Replaced `git push` commands with `ryancyq/github-signed-commit` action in draft_new_release.yml
- Replaced `git push --set-upstream` with GitHub API branch creation in draft_new_release.yml
- Replaced direct git tag push with GitHub API call in publish-new-github-release.yml
- Added environment variables to prevent template injection vulnerabilities
- Moved token generation early in workflow (before checkout)
- Passed App Token to actions/checkout to ensure consistent credentials

## Test plan
- [ ] Verify Notion PR sync still works after merge
- [ ] Test draft release workflow creates verified commits and branches via API
- [ ] Test publish release workflow creates verified tags
- [ ] Verify all CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)